### PR TITLE
Add SmoothCamera and update End_Of_Level_Trigger functionality

### DIFF
--- a/Assets/Prefab/Camera.prefab
+++ b/Assets/Prefab/Camera.prefab
@@ -1,0 +1,157 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2825023722904113185
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7895725893660996245}
+  - component: {fileID: 7832607640068622281}
+  - component: {fileID: 2643385201575853583}
+  - component: {fileID: 2066442033167684871}
+  - component: {fileID: 8832105011097234029}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7895725893660996245
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2825023722904113185}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -22.9, y: -0.5, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &7832607640068622281
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2825023722904113185}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.1
+  far clip plane: 5000
+  field of view: 40
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &2643385201575853583
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2825023722904113185}
+  m_Enabled: 1
+--- !u!114 &2066442033167684871
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2825023722904113185}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalAdditionalCameraData
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!114 &8832105011097234029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2825023722904113185}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d61f5c850d01d31448d62dba6dc29de6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  player: {fileID: 0}
+  <offset>k__BackingField: {x: 7, y: 3.5, z: -10}
+  speedX: 10
+  speedY: 1
+  lockThreshold: 0.1

--- a/Assets/Prefab/Camera.prefab.meta
+++ b/Assets/Prefab/Camera.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 62d15253741af194ea7994487c4d36be
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Entity/Player/SmoothCamera.cs
+++ b/Assets/Scripts/Entity/Player/SmoothCamera.cs
@@ -1,0 +1,80 @@
+using System;
+using UnityEngine;
+
+public class SmoothCamera : MonoBehaviour
+{
+    [SerializeField] private Transform player;
+    [field: SerializeField] public Vector3 offset { get; private set; }
+    
+    [Header("Speeds")]
+    [SerializeField] private float speedX = 10f; 
+    [SerializeField] private float speedY = 10f; 
+    
+    [Tooltip("Distance à laquelle la caméra accroche le joueur")]
+    [SerializeField] private float lockThreshold = 0.5f; 
+
+    private float currentSpeedX;
+    private float currentSpeedY;
+    private Transform currentTarget;
+    private bool isLockedOn;
+
+    private void Awake()
+    {
+        currentSpeedX = speedX;
+        currentSpeedY = speedY;
+        currentTarget = player;
+        EventBus.Subscribe<OnLevelCompletedCallback>(Caca);
+    }
+
+    private void Caca(OnLevelCompletedCallback _)
+    {
+        ChangeTarget(null, 0f, 0f);
+    }
+
+    private void FixedUpdate()
+    {
+        if (currentTarget == null) return;
+
+        Vector3 targetPosition = currentTarget.position + offset;
+
+        if (!isLockedOn)
+        {
+            if (Vector3.Distance(transform.position, targetPosition) <= lockThreshold)
+            {
+                isLockedOn = true; 
+            }
+            else
+            {
+                return;
+            }
+        }
+
+        // Déplacement indépendant pour X et Y
+        float newX = Mathf.MoveTowards(transform.position.x, targetPosition.x, currentSpeedX * Time.fixedDeltaTime);
+        float newY = Mathf.MoveTowards(transform.position.y, targetPosition.y, currentSpeedY * Time.fixedDeltaTime);
+        
+        // Le Z s'aligne instantanément sur la cible + offset (comportement standard en 2D)
+        transform.position = new Vector3(newX, newY, targetPosition.z);
+    }
+
+    public void ChangeTarget(Transform newTarget, float newSpeedX, float newSpeedY)
+    {
+        currentSpeedX = newSpeedX;
+        currentSpeedY = newSpeedY;
+        currentTarget = newTarget;
+        isLockedOn = false; 
+    }
+
+    public void FollowPlayer()
+    {
+        currentSpeedX = speedX;
+        currentSpeedY = speedY;
+        currentTarget = player;
+        isLockedOn = false;
+    }
+
+    private void OnDestroy()
+    {
+        EventBus.Unsubscribe<OnLevelCompletedCallback>(Caca);
+    }
+}

--- a/Assets/Scripts/Entity/Player/SmoothCamera.cs.meta
+++ b/Assets/Scripts/Entity/Player/SmoothCamera.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d61f5c850d01d31448d62dba6dc29de6

--- a/Assets/Scripts/Toys/End_Of_Level_Trigger.cs
+++ b/Assets/Scripts/Toys/End_Of_Level_Trigger.cs
@@ -1,15 +1,24 @@
 using System;
 using UnityEngine;
 
+public struct OnLevelCompletedCallback { }
+
 public class End_Of_Level_Trigger : MonoBehaviour
 {
     [SerializeField] private UI_Basic_Functions VictoryScreen;
-    
+    [SerializeField] private float delayBeforeVictoryScreen;
+
     private void OnTriggerEnter2D(Collider2D other)
     {
-        if (other.gameObject.GetComponent<Player>())
+        if (other.GetComponent<Player>())
         {
-            VictoryScreen.gameObject.SetActive(true);
+            EventBus.Publish(new OnLevelCompletedCallback());
+            Invoke(nameof(TriggerEndOfLevel), delayBeforeVictoryScreen);
         }
+    }
+
+    private void TriggerEndOfLevel()
+    {
+        VictoryScreen.gameObject.SetActive(true);
     }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -8,7 +8,7 @@
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.2d.tilemap.extras": "6.0.1",
     "com.unity.2d.tooling": "1.0.2",
-    "com.unity.cinemachine": "2.10.6",
+    "com.unity.cinemachine": "3.1.6",
     "com.unity.collab-proxy": "2.11.3",
     "com.unity.ide.rider": "3.0.39",
     "com.unity.ide.visualstudio": "2.0.26",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -110,11 +110,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.cinemachine": {
-      "version": "2.10.6",
+      "version": "3.1.6",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.31"
+        "com.unity.splines": "2.0.0",
+        "com.unity.modules.imgui": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -248,6 +249,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.settings-manager": {
+      "version": "2.1.1",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.shadergraph": {
       "version": "17.3.0",
       "depth": 1,
@@ -256,6 +264,17 @@
         "com.unity.render-pipelines.core": "17.3.0",
         "com.unity.searcher": "4.9.3"
       }
+    },
+    "com.unity.splines": {
+      "version": "2.8.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.mathematics": "1.2.1",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.settings-manager": "1.0.3"
+      },
+      "url": "https://packages.unity.com"
     },
     "com.unity.sysroot.base": {
       "version": "1.0.2",


### PR DESCRIPTION
This pull request introduces a new custom camera system to the project, replacing or supplementing Cinemachine with a `SmoothCamera` implementation and associated prefab. It also updates the Cinemachine package to a newer major version and adds supporting Unity packages. Additionally, the end-of-level trigger logic is improved to use event-based communication and delayed UI activation.

**Camera System Implementation:**

* Added a new `SmoothCamera` script (`SmoothCamera.cs`) that smoothly follows the player with configurable speeds, offset, and lock-on threshold, and responds to level completion events. (`[Assets/Scripts/Entity/Player/SmoothCamera.csR1-R80](diffhunk://#diff-8a8ce3320e9bcad51cf0dc964bcdcf3c5ff723cb39411abf60000c79b349fef5R1-R80)`)
* Created a new camera prefab (`Camera.prefab`) configured to use the `SmoothCamera` script and associated Unity components. (`[[1]](diffhunk://#diff-351f4a4402f7de0ad6f1d7102f92c990ecbe7e80a9ae1db18057fb9b32577eeeR1-R157)`, `[[2]](diffhunk://#diff-c6c0a68f576764edbadf6e37b5a97348cd664c8b09ab69eedbf7e39ff668d549R1-R7)`, `[[3]](diffhunk://#diff-ef0f344846d5be89e0c1690fb7f75cdef0358b8bb6e53df3c06a32091cf30777R1-R2)`)

**End-of-Level Event Handling:**

* Refactored `End_Of_Level_Trigger` to publish an `OnLevelCompletedCallback` event and delay the display of the victory screen, improving separation of concerns and timing control. (`[Assets/Scripts/Toys/End_Of_Level_Trigger.csR4-R22](diffhunk://#diff-5a29889cca1286e512f1c17c8de73844e0956fd4b69c32af53cef27180b4292bR4-R22)`)

**Dependency and Package Updates:**

* Upgraded `com.unity.cinemachine` from version 2.10.6 to 3.1.6, and added new dependencies (`com.unity.splines`, `com.unity.settings-manager`, `com.unity.modules.imgui`) to support the updated camera system and Unity features. (`[[1]](diffhunk://#diff-c1991832e77c2a072aa97683b2b773230f3237d79cf720da96303ba012efc59cL11-R11)`, `[[2]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL113-R118)`, `[[3]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aR252-R258)`, `[[4]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aR268-R278)`)Introduce a SmoothCamera MonoBehaviour and Camera prefab to provide smooth, axis-separate camera follow behavior (serializable offset, independent X/Y speeds, lock threshold). SmoothCamera subscribes to an OnLevelCompletedCallback to release the target when level ends.

Update End_Of_Level_Trigger to use OnTriggerEnter2D, add a delayBeforeVictoryScreen, publish OnLevelCompletedCallback on level completion, and invoke showing the victory UI after the delay. Also add corresponding .meta files for new assets.

Bump com.unity.cinemachine in Packages/manifest.json to 3.1.6.